### PR TITLE
Add support for mocked types

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+    "root": true,
     "env": {
         "browser": true,
         "es2021": true,

--- a/types/badge.ts
+++ b/types/badge.ts
@@ -1,20 +1,16 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { DocumentData } from 'firebase/firestore';
 import { LazyObject } from './common';
 
 export class Badge extends LazyObject {
   protected name: string | undefined;
   protected description: string | undefined;
 
-  private async getData() {
-    if (this.hasData) return;
+  protected initWithDocumentData(data: DocumentData) {
+    this.name = data.name;
+    this.description = data.description;
 
-    const data = await this.getDocumentData();
-    if (data !== undefined) {
-      this.name = data.name;
-      this.description = data.description;
-
-      this.hasData = true;
-    }
+    this.hasData = true;
   }
 
   public async getName() {

--- a/types/badge.ts
+++ b/types/badge.ts
@@ -2,8 +2,8 @@
 import { LazyObject } from './common';
 
 export class Badge extends LazyObject {
-  private name: string | undefined;
-  private description: string | undefined;
+  protected name: string | undefined;
+  protected description: string | undefined;
 
   private async getData() {
     if (this.hasData) return;
@@ -25,5 +25,15 @@ export class Badge extends LazyObject {
   public async getDescription() {
     if (!this.hasData) await this.getData();
     return this.description!;
+  }
+}
+
+export class BadgeMock extends Badge {
+  constructor(name: string, description: string) {
+    super();
+    this.name = name;
+    this.description = description;
+
+    this.hasData = true;
   }
 }

--- a/types/badge.ts
+++ b/types/badge.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { LazyObject } from './common';
-import { getDoc } from 'firebase/firestore';
 
 export class Badge extends LazyObject {
   private name: string | undefined;
@@ -8,10 +7,9 @@ export class Badge extends LazyObject {
 
   private async getData() {
     if (this.hasData) return;
-    const docSnap = await getDoc(this.docRef);
-    if (docSnap.exists()) {
-      const data = docSnap.data();
 
+    const data = await this.getDocumentData();
+    if (data !== undefined) {
       this.name = data.name;
       this.description = data.description;
 

--- a/types/comment.ts
+++ b/types/comment.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { LazyObject } from './common';
-import { getDoc } from 'firebase/firestore';
 import { User } from './types';
 
 export class Comment extends LazyObject {
@@ -10,10 +9,9 @@ export class Comment extends LazyObject {
 
   private async getData() {
     if (this.hasData) return;
-    const docSnap = await getDoc(this.docRef);
-    if (docSnap.exists()) {
-      const data = docSnap.data();
 
+    const data = await this.getDocumentData();
+    if (data !== undefined) {
       this.author = new User(data.author);
       this.timestamp = data.timestamp;
       this.textContent = data.textContent;

--- a/types/comment.ts
+++ b/types/comment.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { DocumentData } from 'firebase/firestore';
 import { LazyObject } from './common';
 import { User } from './types';
 
@@ -7,17 +8,12 @@ export class Comment extends LazyObject {
   protected timestamp: Date | undefined;
   protected textContent: string | undefined;
 
-  private async getData() {
-    if (this.hasData) return;
+  protected initWithDocumentData(data: DocumentData) {
+    this.author = new User(data.author);
+    this.timestamp = data.timestamp;
+    this.textContent = data.textContent;
 
-    const data = await this.getDocumentData();
-    if (data !== undefined) {
-      this.author = new User(data.author);
-      this.timestamp = data.timestamp;
-      this.textContent = data.textContent;
-
-      this.hasData = true;
-    }
+    this.hasData = true;
   }
 
   public async getAuthor() {

--- a/types/comment.ts
+++ b/types/comment.ts
@@ -3,9 +3,9 @@ import { LazyObject } from './common';
 import { User } from './types';
 
 export class Comment extends LazyObject {
-  private author: User | undefined;
-  private timestamp: Date | undefined;
-  private textContent: string | undefined;
+  protected author: User | undefined;
+  protected timestamp: Date | undefined;
+  protected textContent: string | undefined;
 
   private async getData() {
     if (this.hasData) return;
@@ -33,5 +33,16 @@ export class Comment extends LazyObject {
   public async getTextContent() {
     if (!this.hasData) await this.getData();
     return this.textContent!;
+  }
+}
+
+export class CommentMock extends Comment {
+  constructor(author: User, timestamp: Date, textContent: string) {
+    super();
+    this.author = author;
+    this.timestamp = timestamp;
+    this.textContent = textContent;
+
+    this.hasData = true;
   }
 }

--- a/types/common.ts
+++ b/types/common.ts
@@ -1,4 +1,4 @@
-import { DocumentReference, DocumentData } from 'firebase/firestore';
+import { DocumentReference, DocumentData, getDoc } from 'firebase/firestore';
 
 export enum UserStatus {
   Unverified = 0,
@@ -10,10 +10,20 @@ export enum UserStatus {
 }
 
 export class LazyObject {
-  protected docRef: DocumentReference<DocumentData>;
+  protected docRef: DocumentReference<DocumentData> | undefined;
   protected hasData: boolean;
 
-  constructor(docRef: DocumentReference<DocumentData>) {
+  protected async getDocumentData(): Promise<DocumentData> {
+    if (this.docRef === undefined)
+      return Promise.reject('Document reference is undefined');
+
+    const docSnap = await getDoc(this.docRef);
+    if (docSnap.exists()) return Promise.resolve(docSnap.data());
+
+    return Promise.reject('Doc snap does not exist');
+  }
+
+  constructor(docRef: DocumentReference<DocumentData> | undefined = undefined) {
     this.docRef = docRef;
     this.hasData = false;
   }

--- a/types/common.ts
+++ b/types/common.ts
@@ -16,7 +16,7 @@ export abstract class LazyObject {
   protected abstract initWithDocumentData(data: DocumentData): void;
 
   protected async getData(): Promise<void> {
-    if(this.hasData) return Promise.resolve();
+    if (this.hasData) return Promise.resolve();
     if (this.docRef === undefined)
       return Promise.reject('Document reference is undefined');
 

--- a/types/common.ts
+++ b/types/common.ts
@@ -9,18 +9,22 @@ export enum UserStatus {
   Developer = 5,
 }
 
-export class LazyObject {
+export abstract class LazyObject {
   protected docRef: DocumentReference<DocumentData> | undefined;
   protected hasData: boolean;
 
-  protected async getDocumentData(): Promise<DocumentData> {
+  protected abstract initWithDocumentData(data: DocumentData): void;
+
+  protected async getData(): Promise<void> {
+    if(this.hasData) return Promise.resolve();
     if (this.docRef === undefined)
       return Promise.reject('Document reference is undefined');
 
     const docSnap = await getDoc(this.docRef);
-    if (docSnap.exists()) return Promise.resolve(docSnap.data());
+    if (!docSnap.exists()) return Promise.reject('Doc snap does not exist');
 
-    return Promise.reject('Doc snap does not exist');
+    await this.initWithDocumentData(docSnap.data());
+    return Promise.resolve();
   }
 
   constructor(docRef: DocumentReference<DocumentData> | undefined = undefined) {

--- a/types/forum.ts
+++ b/types/forum.ts
@@ -4,7 +4,7 @@ import { DocumentReference, DocumentData } from 'firebase/firestore';
 import { Post } from './types';
 
 export class Forum extends LazyObject {
-  private posts: Post[] | undefined;
+  protected posts: Post[] | undefined;
 
   private async getData() {
     if (this.hasData) return;
@@ -22,5 +22,18 @@ export class Forum extends LazyObject {
   public async getPosts() {
     if (!this.hasData) await this.getData();
     return this.posts!;
+  }
+}
+
+export class ForumMock extends Forum {
+  constructor(posts: Post[]) {
+    super();
+    this.posts = posts;
+
+    this.hasData = true;
+  }
+
+  public addPosts(posts: Post[]) {
+    this.posts = this.posts?.concat(posts);
   }
 }

--- a/types/forum.ts
+++ b/types/forum.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { LazyObject } from './common';
-import { DocumentReference, DocumentData, getDoc } from 'firebase/firestore';
+import { DocumentReference, DocumentData } from 'firebase/firestore';
 import { Post } from './types';
 
 export class Forum extends LazyObject {
@@ -8,10 +8,9 @@ export class Forum extends LazyObject {
 
   private async getData() {
     if (this.hasData) return;
-    const docSnap = await getDoc(this.docRef);
-    if (docSnap.exists()) {
-      const data = docSnap.data();
 
+    const data = await this.getDocumentData();
+    if (data !== undefined) {
       this.posts = data.posts.map(
         (ref: DocumentReference<DocumentData>) => new Post(ref)
       );

--- a/types/forum.ts
+++ b/types/forum.ts
@@ -6,17 +6,12 @@ import { Post } from './types';
 export class Forum extends LazyObject {
   protected posts: Post[] | undefined;
 
-  private async getData() {
-    if (this.hasData) return;
+  protected initWithDocumentData(data: DocumentData) {
+    this.posts = data.posts.map(
+      (ref: DocumentReference<DocumentData>) => new Post(ref)
+    );
 
-    const data = await this.getDocumentData();
-    if (data !== undefined) {
-      this.posts = data.posts.map(
-        (ref: DocumentReference<DocumentData>) => new Post(ref)
-      );
-
-      this.hasData = true;
-    }
+    this.hasData = true;
   }
 
   public async getPosts() {

--- a/types/post.ts
+++ b/types/post.ts
@@ -4,11 +4,11 @@ import { DocumentReference, DocumentData } from 'firebase/firestore';
 import { Comment, User } from './types';
 
 export class Post extends LazyObject {
-  private author: User | undefined;
-  private timestamp: Date | undefined;
-  private textContent: string | undefined;
-  private likes: User[] | undefined;
-  private comments: Comment[] | undefined;
+  protected author: User | undefined;
+  protected timestamp: Date | undefined;
+  protected textContent: string | undefined;
+  protected likes: User[] | undefined;
+  protected comments: Comment[] | undefined;
 
   private async getData() {
     if (this.hasData) return;
@@ -52,5 +52,32 @@ export class Post extends LazyObject {
   public async getComments() {
     if (!this.hasData) await this.getData();
     return this.comments!;
+  }
+}
+
+export class PostMock extends Post {
+  constructor(
+    author: User,
+    timestamp: Date,
+    textContent: string,
+    likes: User[],
+    comments: Comment[]
+  ) {
+    super();
+    this.author = author;
+    this.timestamp = timestamp;
+    this.textContent = textContent;
+    this.likes = likes;
+    this.comments = comments;
+
+    this.hasData = true;
+  }
+
+  public addLikes(likes: User[]) {
+    this.likes = this.likes?.concat(likes);
+  }
+
+  public addComments(comments: Comment[]) {
+    this.comments = this.comments?.concat(comments);
   }
 }

--- a/types/post.ts
+++ b/types/post.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { LazyObject } from './common';
-import { DocumentReference, DocumentData, getDoc } from 'firebase/firestore';
+import { DocumentReference, DocumentData } from 'firebase/firestore';
 import { Comment, User } from './types';
 
 export class Post extends LazyObject {
@@ -12,10 +12,9 @@ export class Post extends LazyObject {
 
   private async getData() {
     if (this.hasData) return;
-    const docSnap = await getDoc(this.docRef);
-    if (docSnap.exists()) {
-      const data = docSnap.data();
 
+    const data = await this.getDocumentData();
+    if (data !== undefined) {
       this.author = new User(data.author);
       this.timestamp = data.timestamp;
       this.textContent = data.textContent;

--- a/types/post.ts
+++ b/types/post.ts
@@ -10,23 +10,18 @@ export class Post extends LazyObject {
   protected likes: User[] | undefined;
   protected comments: Comment[] | undefined;
 
-  private async getData() {
-    if (this.hasData) return;
+  protected initWithDocumentData(data: DocumentData) {
+    this.author = new User(data.author);
+    this.timestamp = data.timestamp;
+    this.textContent = data.textContent;
+    this.likes = data.likes.map(
+      (ref: DocumentReference<DocumentData>) => new User(ref)
+    );
+    this.comments = data.comments.map(
+      (ref: DocumentReference<DocumentData>) => new Comment(ref)
+    );
 
-    const data = await this.getDocumentData();
-    if (data !== undefined) {
-      this.author = new User(data.author);
-      this.timestamp = data.timestamp;
-      this.textContent = data.textContent;
-      this.likes = data.likes.map(
-        (ref: DocumentReference<DocumentData>) => new User(ref)
-      );
-      this.comments = data.comments.map(
-        (ref: DocumentReference<DocumentData>) => new Comment(ref)
-      );
-
-      this.hasData = true;
-    }
+    this.hasData = true;
   }
 
   public async getAuthor() {

--- a/types/route.ts
+++ b/types/route.ts
@@ -11,24 +11,19 @@ export class Route extends LazyObject {
   protected likes: User[] | undefined;
   protected tags: Tag[] | undefined;
 
-  private async getData() {
-    if (this.hasData) return;
+  protected initWithDocumentData(data: DocumentData): void {
+    this.name = data.name;
+    this.rating = data.rating;
+    this.setter = new User(data.setter);
+    this.forum = new Forum(data.forum);
+    this.likes = data.likes.map(
+      (ref: DocumentReference<DocumentData>) => new User(ref)
+    );
+    this.tags = data.tags.map(
+      (ref: DocumentReference<DocumentData>) => new Tag(ref)
+    );
 
-    const data = await this.getDocumentData();
-    if (data !== undefined) {
-      this.name = data.name;
-      this.rating = data.rating;
-      this.setter = new User(data.setter);
-      this.forum = new Forum(data.forum);
-      this.likes = data.likes.map(
-        (ref: DocumentReference<DocumentData>) => new User(ref)
-      );
-      this.tags = data.tags.map(
-        (ref: DocumentReference<DocumentData>) => new Tag(ref)
-      );
-
-      this.hasData = true;
-    }
+    this.hasData = true;
   }
 
   public async getName() {

--- a/types/route.ts
+++ b/types/route.ts
@@ -4,12 +4,12 @@ import { DocumentReference, DocumentData } from 'firebase/firestore';
 import { User, Tag, Forum } from './types';
 
 export class Route extends LazyObject {
-  private name: string | undefined;
-  private rating: string | undefined;
-  private setter: User | undefined;
-  private forum: Forum | undefined;
-  private likes: User[] | undefined;
-  private tags: Tag[] | undefined;
+  protected name: string | undefined;
+  protected rating: string | undefined;
+  protected setter: User | undefined;
+  protected forum: Forum | undefined;
+  protected likes: User[] | undefined;
+  protected tags: Tag[] | undefined;
 
   private async getData() {
     if (this.hasData) return;
@@ -59,5 +59,34 @@ export class Route extends LazyObject {
   public async getTags() {
     if (!this.hasData) await this.getData();
     return this.tags!;
+  }
+}
+
+export class RouteMock extends Route {
+  constructor(
+    name: string,
+    rating: string,
+    setter: User,
+    forum: Forum,
+    likes: User[],
+    tags: Tag[]
+  ) {
+    super();
+    this.name = name;
+    this.rating = rating;
+    this.setter = setter;
+    this.forum = forum;
+    this.likes = likes;
+    this.tags = tags;
+
+    this.hasData = true;
+  }
+
+  public addLikes(likes: User[]) {
+    this.likes = this.likes?.concat(likes);
+  }
+
+  public addTags(tags: Tag[]) {
+    this.tags = this.tags?.concat(tags);
   }
 }

--- a/types/route.ts
+++ b/types/route.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { LazyObject } from './common';
-import { DocumentReference, DocumentData, getDoc } from 'firebase/firestore';
+import { DocumentReference, DocumentData } from 'firebase/firestore';
 import { User, Tag, Forum } from './types';
 
 export class Route extends LazyObject {
@@ -13,10 +13,9 @@ export class Route extends LazyObject {
 
   private async getData() {
     if (this.hasData) return;
-    const docSnap = await getDoc(this.docRef);
-    if (docSnap.exists()) {
-      const data = docSnap.data();
 
+    const data = await this.getDocumentData();
+    if (data !== undefined) {
       this.name = data.name;
       this.rating = data.rating;
       this.setter = new User(data.setter);

--- a/types/send.ts
+++ b/types/send.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { DocumentData } from 'firebase/firestore';
 import { LazyObject } from './common';
 import { Route } from './types';
 
@@ -7,17 +8,12 @@ export class Send extends LazyObject {
   protected timestamp: Date | undefined;
   protected route: Route | undefined;
 
-  private async getData() {
-    if (this.hasData) return;
+  protected initWithDocumentData(data: DocumentData): void {
+    this.attempts = data.attempts;
+    this.timestamp = data.timestamp;
+    this.route = new Route(data.route);
 
-    const data = await this.getDocumentData();
-    if (data !== undefined) {
-      this.attempts = data.attempts;
-      this.timestamp = data.timestamp;
-      this.route = new Route(data.route);
-
-      this.hasData = true;
-    }
+    this.hasData = true;
   }
 
   public async getAttempts() {

--- a/types/send.ts
+++ b/types/send.ts
@@ -3,9 +3,9 @@ import { LazyObject } from './common';
 import { Route } from './types';
 
 export class Send extends LazyObject {
-  private attempts: number | undefined;
-  private timestamp: Date | undefined;
-  private route: Route | undefined;
+  protected attempts: number | undefined;
+  protected timestamp: Date | undefined;
+  protected route: Route | undefined;
 
   private async getData() {
     if (this.hasData) return;
@@ -33,5 +33,16 @@ export class Send extends LazyObject {
   public async getRoute() {
     if (!this.hasData) await this.getData();
     return this.route!;
+  }
+}
+
+export class SendMock extends Send {
+  constructor(attempts: number, timestamp: Date, route: Route) {
+    super();
+    this.attempts = attempts;
+    this.timestamp = timestamp;
+    this.route = route;
+
+    this.hasData = true;
   }
 }

--- a/types/send.ts
+++ b/types/send.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { LazyObject } from './common';
-import { getDoc } from 'firebase/firestore';
 import { Route } from './types';
 
 export class Send extends LazyObject {
@@ -10,10 +9,9 @@ export class Send extends LazyObject {
 
   private async getData() {
     if (this.hasData) return;
-    const docSnap = await getDoc(this.docRef);
-    if (docSnap.exists()) {
-      const data = docSnap.data();
 
+    const data = await this.getDocumentData();
+    if (data !== undefined) {
       this.attempts = data.attempts;
       this.timestamp = data.timestamp;
       this.route = new Route(data.route);

--- a/types/tag.ts
+++ b/types/tag.ts
@@ -2,8 +2,8 @@
 import { LazyObject } from './common';
 
 export class Tag extends LazyObject {
-  private name: string | undefined;
-  private description: string | undefined;
+  protected name: string | undefined;
+  protected description: string | undefined;
 
   private async getData() {
     if (this.hasData) return;
@@ -25,5 +25,15 @@ export class Tag extends LazyObject {
   public async getDescription() {
     if (!this.hasData) await this.getData();
     return this.description!;
+  }
+}
+
+export class TagMock extends Tag {
+  constructor(name: string, description: string) {
+    super();
+    this.name = name;
+    this.description = description;
+
+    this.hasData = true;
   }
 }

--- a/types/tag.ts
+++ b/types/tag.ts
@@ -1,20 +1,16 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { DocumentData } from 'firebase/firestore';
 import { LazyObject } from './common';
 
 export class Tag extends LazyObject {
   protected name: string | undefined;
   protected description: string | undefined;
 
-  private async getData() {
-    if (this.hasData) return;
+  protected initWithDocumentData(data: DocumentData): void {
+    this.name = data.name;
+    this.description = data.description;
 
-    const data = await this.getDocumentData();
-    if (data !== undefined) {
-      this.name = data.name;
-      this.description = data.description;
-
-      this.hasData = true;
-    }
+    this.hasData = true;
   }
 
   public async getName() {

--- a/types/tag.ts
+++ b/types/tag.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { LazyObject } from './common';
-import { getDoc } from 'firebase/firestore';
 
 export class Tag extends LazyObject {
   private name: string | undefined;
@@ -8,10 +7,9 @@ export class Tag extends LazyObject {
 
   private async getData() {
     if (this.hasData) return;
-    const docSnap = await getDoc(this.docRef);
-    if (docSnap.exists()) {
-      const data = docSnap.data();
 
+    const data = await this.getDocumentData();
+    if (data !== undefined) {
       this.name = data.name;
       this.description = data.description;
 

--- a/types/user.ts
+++ b/types/user.ts
@@ -4,13 +4,13 @@ import { DocumentReference, DocumentData } from 'firebase/firestore';
 import { Send } from './types';
 
 export class User extends LazyObject {
-  private username: string | undefined;
-  private passwordHash: string | undefined;
-  private bio: string | undefined;
-  private status: UserStatus | undefined;
-  private sends: Send[] | undefined;
-  private following: User[] | undefined;
-  private followers: User[] | undefined;
+  protected username: string | undefined;
+  protected passwordHash: string | undefined;
+  protected bio: string | undefined;
+  protected status: UserStatus | undefined;
+  protected sends: Send[] | undefined;
+  protected following: User[] | undefined;
+  protected followers: User[] | undefined;
 
   private async getData() {
     if (this.hasData) return;
@@ -68,5 +68,38 @@ export class User extends LazyObject {
   public async getFollowers() {
     if (!this.hasData) await this.getData();
     return this.followers!;
+  }
+}
+
+export class UserMock extends User {
+  constructor(
+    username: string,
+    passwordHash: string,
+    bio: string,
+    status: UserStatus,
+    sends: Send[],
+    following: User[],
+    followers: User[]
+  ) {
+    super();
+    this.username = username;
+    this.passwordHash = passwordHash;
+    this.bio = bio;
+    this.status = status;
+    this.sends = sends;
+    this.following = following;
+    this.followers = followers;
+  }
+
+  public addSends(sends: Send[]) {
+    this.sends = this.sends?.concat(sends);
+  }
+
+  public addFollowing(following: User[]) {
+    this.following = this.following?.concat(following);
+  }
+
+  public addFollowers(followers: User[]) {
+    this.followers = this.followers?.concat(followers);
   }
 }

--- a/types/user.ts
+++ b/types/user.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { LazyObject, UserStatus } from './common';
-import { DocumentReference, DocumentData, getDoc } from 'firebase/firestore';
+import { DocumentReference, DocumentData } from 'firebase/firestore';
 import { Send } from './types';
 
 export class User extends LazyObject {
@@ -14,10 +14,9 @@ export class User extends LazyObject {
 
   private async getData() {
     if (this.hasData) return;
-    const docSnap = await getDoc(this.docRef);
-    if (docSnap.exists()) {
-      const data = docSnap.data();
 
+    const data = await this.getDocumentData();
+    if (data !== undefined) {
       this.username = data.username;
       this.passwordHash = data.passwordHash;
       this.bio = data.bio;

--- a/types/user.ts
+++ b/types/user.ts
@@ -5,44 +5,32 @@ import { Send } from './types';
 
 export class User extends LazyObject {
   protected username: string | undefined;
-  protected passwordHash: string | undefined;
   protected bio: string | undefined;
   protected status: UserStatus | undefined;
   protected sends: Send[] | undefined;
   protected following: User[] | undefined;
   protected followers: User[] | undefined;
 
-  private async getData() {
-    if (this.hasData) return;
+  protected initWithDocumentData(data: DocumentData): void {
+    this.username = data.username;
+    this.bio = data.bio;
+    this.status = data.status as UserStatus;
+    this.sends = data.sends.map(
+      (ref: DocumentReference<DocumentData>) => new Send(ref)
+    );
+    this.following = data.following.map(
+      (ref: DocumentReference<DocumentData>) => new User(ref)
+    );
+    this.followers = data.followers.map(
+      (ref: DocumentReference<DocumentData>) => new User(ref)
+    );
 
-    const data = await this.getDocumentData();
-    if (data !== undefined) {
-      this.username = data.username;
-      this.passwordHash = data.passwordHash;
-      this.bio = data.bio;
-      this.status = data.status as UserStatus;
-      this.sends = data.sends.map(
-        (ref: DocumentReference<DocumentData>) => new Send(ref)
-      );
-      this.following = data.following.map(
-        (ref: DocumentReference<DocumentData>) => new User(ref)
-      );
-      this.followers = data.followers.map(
-        (ref: DocumentReference<DocumentData>) => new User(ref)
-      );
-
-      this.hasData = true;
-    }
+    this.hasData = true;
   }
 
   public async getUsername() {
     if (!this.hasData) await this.getData();
     return this.username!;
-  }
-
-  public async getPasswordHash() {
-    if (!this.hasData) await this.getData();
-    return this.passwordHash!;
   }
 
   public async getBio() {
@@ -74,7 +62,6 @@ export class User extends LazyObject {
 export class UserMock extends User {
   constructor(
     username: string,
-    passwordHash: string,
     bio: string,
     status: UserStatus,
     sends: Send[],
@@ -83,7 +70,6 @@ export class UserMock extends User {
   ) {
     super();
     this.username = username;
-    this.passwordHash = passwordHash;
     this.bio = bio;
     this.status = status;
     this.sends = sends;


### PR DESCRIPTION
In development environments, we often find ourselves without `docRef`s to fetch for testing objects. This branch adds support for mocked types.

1. Abstract the data fetch into the `LazyObject`, return a `Promise`. Adjust callees to use new API
2. Create Mock objects for all types. Support modification of data for dynamic tests.