### PR TITLE
Set hasData to true

### DIFF
--- a/types/user.ts
+++ b/types/user.ts
@@ -113,6 +113,8 @@ export class UserMock extends User {
     this.sends = sends;
     this.following = following;
     this.followers = followers;
+
+    this.hasData = true;
   }
 
   public addSends(sends: Send[]) {


### PR DESCRIPTION
## Describe your changes
Since a mock does not create a valid document reference, it must set it's `hasData` field to true. This was done correctly for all other mocks, but missed for `User`. This PR fixes the bug.

## Issue ticket number and link
#13 

## Checklist before requesting a review
- [x] All code is linted and conforms to style guide
- [x] All necessary context is described in the PR or Issue
- [x] This branch is code and feature complete. If it is not complete, this PR is a draft.
