### PR TITLE
De-generify route status and grades

### DIFF
--- a/Firebase.ts
+++ b/Firebase.ts
@@ -13,3 +13,7 @@ export const auth = getAuth();
 export const storage = getStorage();
 
 export const DEFAULT_AVATAR_PATH = 'avatars/climber.png';
+export const BOULDER_ROUTETYPE = 'Boulder';
+export const TOPROPE_ROUTETYPE = 'Top-Rope';
+export const TRAVERSE_ROUTETYPE = 'Traverse';
+export const LEADCLIMB_ROUTETYPE = 'Lead-Climb';

--- a/Firebase.ts
+++ b/Firebase.ts
@@ -13,7 +13,3 @@ export const auth = getAuth();
 export const storage = getStorage();
 
 export const DEFAULT_AVATAR_PATH = 'avatars/climber.png';
-export const BOULDER_ROUTETYPE = 'Boulder';
-export const TOPROPE_ROUTETYPE = 'Top-Rope';
-export const TRAVERSE_ROUTETYPE = 'Traverse';
-export const LEADCLIMB_ROUTETYPE = 'Lead-Climb';

--- a/api/route.ts
+++ b/api/route.ts
@@ -9,7 +9,7 @@ import {
 } from 'firebase/firestore';
 import { ref, uploadBytes } from 'firebase/storage';
 import { db, storage } from '../Firebase';
-import { Route, RouteStatus, Tag, User } from '../types/types';
+import { Route, RouteClassifier, RouteStatus, Tag, User } from '../types/types';
 
 /** getRouteById
  * Returns a Firebase Route corresponding to the document ID provided
@@ -24,8 +24,7 @@ export function getRouteById(routeId: string) {
 
 export interface CreateRouteArgs {
   name: string;
-  rating: string;
-  type: string;
+  classifier: RouteClassifier;
   description?: string;
   tags?: Tag[];
   setter?: User;
@@ -36,8 +35,7 @@ export interface CreateRouteArgs {
 /** createRoute
  * Creates a route
  * @param name: The route's name
- * @param rating: The route's rating, e.g. 'V0', '5.12+'
- * @param type: The route's type, e.g. 'Boulder'
+ * @param classifier: The route's classifier
  * @param description: Optional, the route's description
  * @param tags: Optional, a list of Tag, the route's tags
  * @param setter: Optional, the Tower User of the setter
@@ -47,8 +45,7 @@ export interface CreateRouteArgs {
  */
 export async function createRoute({
   name,
-  rating,
-  type,
+  classifier,
   description = undefined,
   tags = undefined,
   setter = undefined,
@@ -75,8 +72,8 @@ export async function createRoute({
     transaction.update(cacheDocRef, { routeNameToRoute: routeNameToRoute });
     transaction.set(newRouteDocRef, {
       name: name,
-      rating: rating,
-      type: type,
+      rawgrade: classifier.rawgrade,
+      type: classifier.type as string,
       ...(setter && { setter: setter.docRef! }),
       ...(rope && { rope: rope }),
       ...(tags && { tags: tags }),

--- a/api/route.ts
+++ b/api/route.ts
@@ -9,7 +9,14 @@ import {
 } from 'firebase/firestore';
 import { ref, uploadBytes } from 'firebase/storage';
 import { db, storage } from '../Firebase';
-import { Route, RouteClassifier, RouteStatus, Tag, User } from '../types/types';
+import {
+  Route,
+  RouteClassifier,
+  RouteStatus,
+  RouteType,
+  Tag,
+  User,
+} from '../types/types';
 
 /** getRouteById
  * Returns a Firebase Route corresponding to the document ID provided
@@ -113,4 +120,59 @@ export async function getAllRoutes() {
     await getDoc(cacheDocRef)
   ).data()!.routeNameToRoute;
   return Object.values(routeNameToRoute).map((ref) => new Route(ref));
+}
+
+/** getAllBoulderClassifiers
+ * Get list of all boulder classifiers
+ */
+export function getAllBoulderClassifiers() {
+  return [-1, 0, 1, 2, 3, 4, 5, 6, 7].map(
+    (x) => new RouteClassifier(x, RouteType.Boulder)
+  );
+}
+
+/** getAllTraverseRouteClassifiers
+ * Get list of all traverse classifiers
+ */
+export function getAllTraverseRouteClassifiers() {
+  return [1, 2, 3, 4].map((x) => new RouteClassifier(x, RouteType.Traverse));
+}
+
+/** getAllTopropeRouteClassifiers
+ * Get list of all toprope classifiers
+ */
+export function getAllTopropeRouteClassifiers() {
+  return [
+    49, 50, 51, 59, 60, 61, 69, 70, 71, 79, 80, 81, 89, 90, 91, 99, 100, 101,
+    109, 110, 111, 119, 120, 121, 129, 130, 131,
+  ].map((x) => new RouteClassifier(x, RouteType.Toprope));
+}
+
+/** getAllLeadclimbRouteClassifiers
+ * Get list of all lead climb classifiers
+ */
+export function getAllLeadclimbRouteClassifiers() {
+  return [
+    49, 50, 51, 59, 60, 61, 69, 70, 71, 79, 80, 81, 89, 90, 91, 99, 100, 101,
+    109, 110, 111, 119, 120, 121, 129, 130, 131,
+  ].map((x) => new RouteClassifier(x, RouteType.Leadclimb));
+}
+
+/** getAllCompetitionRouteClassifiers
+ * Get list of all comp route classifiers
+ */
+export function getAllCompetitionRouteClassifiers() {
+  return [1, 2, 3, 4].map((x) => new RouteClassifier(x, RouteType.Competition));
+}
+
+/** getAllRouteClassifiers
+ * Get list of all route classifiers of all types
+ */
+export function getAllRouteClassifiers() {
+  return getAllBoulderClassifiers().concat(
+    getAllTraverseRouteClassifiers(),
+    getAllLeadclimbRouteClassifiers(),
+    getAllCompetitionRouteClassifiers(),
+    getAllTopropeRouteClassifiers()
+  );
 }

--- a/api/route.ts
+++ b/api/route.ts
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import {
+  DocumentReference,
+  Transaction,
   collection,
   doc,
-  DocumentReference,
   getDoc,
   runTransaction,
-  Transaction,
 } from 'firebase/firestore';
 import { ref, uploadBytes } from 'firebase/storage';
 import { db, storage } from '../Firebase';
@@ -36,8 +36,13 @@ export interface CreateRouteArgs {
 /** createRoute
  * Creates a route
  * @param name: The route's name
- * @param rating: The route's rating
- * @param setter: The Tower User of the setter, or undefined. Defaults to undefined.
+ * @param rating: The route's rating, e.g. 'V0', '5.12+'
+ * @param type: The route's type, e.g. 'Boulder'
+ * @param description: Optional, the route's description
+ * @param tags: Optional, a list of Tag, the route's tags
+ * @param setter: Optional, the Tower User of the setter
+ * @param rope: Optional, which rope the route is on / closest to
+ * @param thumbnail: Optional, the route's thumbnail
  * @returns The newly created Route
  */
 export async function createRoute({

--- a/types/common.ts
+++ b/types/common.ts
@@ -4,7 +4,7 @@ import {
   DocumentReference,
   getDoc,
   refEqual,
-  Transaction
+  Transaction,
 } from 'firebase/firestore';
 
 export enum UserStatus {
@@ -13,13 +13,13 @@ export enum UserStatus {
   Approved = 2,
   Employee = 3,
   Manager = 4,
-  Developer = 5
+  Developer = 5,
 }
 
 export enum RouteStatus {
   Draft = 0,
   Active = 1,
-  Archived = 2
+  Archived = 2,
 }
 
 export class ArrayCursor<T> {
@@ -55,7 +55,7 @@ export abstract class LazyObject {
 
   protected abstract initWithDocumentData(data: DocumentData): void;
 
-  public async getData(forceUpdate: boolean = false): Promise<void> {
+  public async getData(forceUpdate = false): Promise<void> {
     if (this.hasData && !forceUpdate) return;
     if (this.docRef === undefined)
       return Promise.reject('Document reference is undefined');

--- a/types/common.ts
+++ b/types/common.ts
@@ -16,12 +16,6 @@ export enum UserStatus {
   Developer = 5,
 }
 
-export enum RouteStatus {
-  Draft = 0,
-  Active = 1,
-  Archived = 2,
-}
-
 export class ArrayCursor<T> {
   public data: T[];
   private idx: number;


### PR DESCRIPTION
Before filling out the Pull Request body, please ensure you have written a meaningful and descriptive title.

## Describe your changes
Add enum `RouteType`, self-explanatory
Add class `RouteClassifier` which is constructed with `rawgrade` and `routeType`; rawgrade is stored directly in the firebase document, routeType is trivially constructed from a direct document field. This class computes and stores `displayString` which is a human-readable version of the combined `rawgrade` and `routeType`. There's a little magic-numbery stuff going on here, but it's *only* located in this one spot and the rest of the code is agnostic.

The reason is so that we can perform a strong ordering *in the firebase schema* by grouping by type and sorting by rawgrade. It'll also make the UI easier to implement. 

## Issue ticket number and link
#77 

## Checklist before requesting a review
- [x] All code is linted and conforms to style guide
- [x] All necessary context is described in the PR or Issue
- [x] This branch is code and feature complete. If it is not complete, this PR is a draft.
