### PR TITLE
Revise/user create

### DIFF
--- a/api/user.ts
+++ b/api/user.ts
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import {
+  UserCredential,
   createUserWithEmailAndPassword,
   sendEmailVerification,
   signInWithEmailAndPassword,
-  UserCredential,
 } from 'firebase/auth';
-import { doc, getDoc, runTransaction, Transaction } from 'firebase/firestore';
+import { Transaction, doc, getDoc, runTransaction } from 'firebase/firestore';
 import { auth, db } from '../Firebase';
 import { User, UserStatus } from '../types/types';
 
@@ -16,6 +16,22 @@ import { User, UserStatus } from '../types/types';
  */
 export function isKnightsEmail(email: string): boolean {
   return email.endsWith('@knights.ucf.edu') || email.endsWith('@ucf.edu');
+}
+
+/** validUsername
+ * Check whether a username is 5-15 lowercase a-z characters
+ * @param username
+ */
+export function validUsername(username: string): boolean {
+  return username.match('^[a-z]{5,15}$') !== null;
+}
+
+/** validDisplayname
+ * Check whether a username is 5-30 lower or upper a-z characters plus spaces, with no leading or trailing spaces
+ * @param username
+ */
+export function validDisplayname(displayname: string): boolean {
+  return displayname.match('^[a-zA-Z][a-zA-Z ]{3,28}[a-zA-Z]$') !== null;
 }
 
 /** createUser
@@ -34,6 +50,9 @@ export async function createUser(
   username: string,
   displayName: string
 ) {
+  if (!validUsername(username)) return Promise.reject('Invalid Username!');
+  if (!validDisplayname(displayName))
+    return Promise.reject('Invalid Display Name!');
   if (await getUserByUsername(username))
     return Promise.reject('Username taken');
   return createUserWithEmailAndPassword(auth, email, password).then(

--- a/types/user.ts
+++ b/types/user.ts
@@ -16,6 +16,7 @@ import {
 } from 'firebase/firestore';
 import { deleteObject } from 'firebase/storage';
 import { DEFAULT_AVATAR_PATH, auth, db } from '../Firebase';
+import { isKnightsEmail } from '../api';
 import { LazyObject, UserStatus, containsRef } from './common';
 import { Comment, LazyStaticImage, Post, Send } from './types';
 
@@ -180,6 +181,12 @@ export class User extends LazyObject {
     console.log('Document deleted');
     await deleteUser(auth.currentUser!);
     console.log('Auth deleted');
+  }
+
+  public verifyEmailWithinTransaction(email: string, transaction: Transaction) {
+    if (isKnightsEmail(email)) this.status = UserStatus.Approved;
+    else this.status = UserStatus.Verified;
+    transaction.update(this.docRef!, { status: this.status });
   }
 
   // ======================== Trivial Getters Below ========================


### PR DESCRIPTION
# Describe your changes
- Modify the `startWaitForVerificationPoll` to update the user's status when the email is verified, to `Verified` or `Approved` accordingly. 
- Revise the signature to provide the new User object to the callback so the email verification listener has the new User object straight away.
- Remove the auto-verification in `getCurrentUser` since it's always done on email verification now, and app login is blocked by it so we always perform the knight email check
# Issue ticket number and link
#87 