### PR TITLE
Add support for grade string to classifier

### DIFF
--- a/__tests__/route.ts
+++ b/__tests__/route.ts
@@ -1,0 +1,39 @@
+import {
+  convertBoulderStringToClassifier,
+  convertCompetitionStringToClassifier,
+  convertLeadclimbStringToClassifier,
+  convertTopropeStringToClassifier,
+  convertTraverseStringToClassifier,
+} from '../api';
+
+test('boulder strings are properly converted to their RouteClassifier', () => {
+  expect(convertBoulderStringToClassifier('VB').rawgrade).toBe(-1);
+  expect(convertBoulderStringToClassifier('V0').rawgrade).toBe(0);
+  expect(convertBoulderStringToClassifier('V1').rawgrade).toBe(1);
+});
+
+test('traverse strings are properly converted to their RouteClassifier', () => {
+  expect(convertTraverseStringToClassifier('A').rawgrade).toBe(1);
+  expect(convertTraverseStringToClassifier('B').rawgrade).toBe(2);
+  expect(convertTraverseStringToClassifier('Z').rawgrade).toBe(26);
+});
+
+test('toprope strings are properly converted to their RouteClassifier', () => {
+  expect(convertTopropeStringToClassifier('5.6-').rawgrade).toBe(59);
+  expect(convertTopropeStringToClassifier('5.6').rawgrade).toBe(60);
+  expect(convertTopropeStringToClassifier('5.6+').rawgrade).toBe(61);
+  expect(convertTopropeStringToClassifier('5.7').rawgrade).toBe(70);
+});
+
+test('leadclimb strings are properly converted to their RouteClassifier', () => {
+  expect(convertLeadclimbStringToClassifier('5.6-').rawgrade).toBe(59);
+  expect(convertLeadclimbStringToClassifier('5.6').rawgrade).toBe(60);
+  expect(convertLeadclimbStringToClassifier('5.6+').rawgrade).toBe(61);
+  expect(convertLeadclimbStringToClassifier('5.7').rawgrade).toBe(70);
+});
+
+test('competition strings are properly converted to their RouteClassifier', () => {
+  expect(convertCompetitionStringToClassifier('A').rawgrade).toBe(1);
+  expect(convertCompetitionStringToClassifier('B').rawgrade).toBe(2);
+  expect(convertCompetitionStringToClassifier('Z').rawgrade).toBe(26);
+});

--- a/api/__tests__/route.ts
+++ b/api/__tests__/route.ts
@@ -4,7 +4,7 @@ import {
   convertLeadclimbStringToClassifier,
   convertTopropeStringToClassifier,
   convertTraverseStringToClassifier,
-} from '../api';
+} from '../route';
 
 test('boulder strings are properly converted to their RouteClassifier', () => {
   expect(convertBoulderStringToClassifier('VB').rawgrade).toBe(-1);

--- a/api/route.ts
+++ b/api/route.ts
@@ -136,11 +136,31 @@ export function getAllBoulderClassifiers() {
   );
 }
 
+/** convertBoulderStringToClassifier
+ * Turns a boulder grade string into its classifier
+ * @param boulderString: The boulder string to convert
+ */
+export function convertBoulderStringToClassifier(boulderString: string) {
+  const rawgrade = boulderString.includes('-1')
+    ? -1
+    : parseInt(boulderString[boulderString.length - 1]);
+  return new RouteClassifier(rawgrade, RouteType.Boulder);
+}
+
 /** getAllTraverseRouteClassifiers
  * Get list of all traverse classifiers
  */
 export function getAllTraverseRouteClassifiers() {
   return [1, 2, 3, 4].map((x) => new RouteClassifier(x, RouteType.Traverse));
+}
+
+/** convertTraverseStringToClassifier
+ * Turns a traverse grade string into its classifier
+ * @param traverseString: The traverse string to convert
+ */
+export function convertTraverseStringToClassifier(traverseString: string) {
+  const rawgrade = traverseString.charCodeAt(0) - 'A'.charCodeAt(0);
+  return new RouteClassifier(rawgrade, RouteType.Traverse);
 }
 
 /** getAllTopropeRouteClassifiers
@@ -153,6 +173,17 @@ export function getAllTopropeRouteClassifiers() {
   ].map((x) => new RouteClassifier(x, RouteType.Toprope));
 }
 
+/** convertTopropeStringToClassifier
+ * Turns a toprope grade string into its classifier
+ * @param topropeString: The toprope string to convert
+ */
+export function convertTopropeStringToClassifier(topropeString: string) {
+  let rawgrade = parseInt(topropeString.split('.')[1]) * 10;
+  if (topropeString.endsWith('-')) rawgrade--;
+  else if (topropeString.endsWith('+')) rawgrade++;
+  return new RouteClassifier(rawgrade, RouteType.Toprope);
+}
+
 /** getAllLeadclimbRouteClassifiers
  * Get list of all lead climb classifiers
  */
@@ -163,11 +194,33 @@ export function getAllLeadclimbRouteClassifiers() {
   ].map((x) => new RouteClassifier(x, RouteType.Leadclimb));
 }
 
+/** convertLeadclimbStringToClassifier
+ * Turns a leadclimb grade string into its classifier
+ * @param leadclimbString: The leadclimb string to convert
+ */
+export function convertLeadclimbStringToClassifier(leadclimbString: string) {
+  let rawgrade = parseInt(leadclimbString.split('.')[1]) * 10;
+  if (leadclimbString.endsWith('-')) rawgrade--;
+  else if (leadclimbString.endsWith('+')) rawgrade++;
+  return new RouteClassifier(rawgrade, RouteType.Leadclimb);
+}
+
 /** getAllCompetitionRouteClassifiers
  * Get list of all comp route classifiers
  */
 export function getAllCompetitionRouteClassifiers() {
   return [1, 2, 3, 4].map((x) => new RouteClassifier(x, RouteType.Competition));
+}
+
+/** convertCompetitionStringToClassifier
+ * Turns a competition grade string into its classifier
+ * @param competitionString: The competition string to convert
+ */
+export function convertCompetitionStringToClassifier(
+  competitionString: string
+) {
+  const rawgrade = competitionString.charCodeAt(0) - 'A'.charCodeAt(0);
+  return new RouteClassifier(rawgrade, RouteType.Competition);
 }
 
 /** getAllRouteClassifiers

--- a/api/route.ts
+++ b/api/route.ts
@@ -141,7 +141,7 @@ export function getAllBoulderClassifiers() {
  * @param boulderString: The boulder string to convert
  */
 export function convertBoulderStringToClassifier(boulderString: string) {
-  const rawgrade = boulderString.includes('-1')
+  const rawgrade = boulderString.endsWith('B')
     ? -1
     : parseInt(boulderString[boulderString.length - 1]);
   return new RouteClassifier(rawgrade, RouteType.Boulder);
@@ -159,7 +159,7 @@ export function getAllTraverseRouteClassifiers() {
  * @param traverseString: The traverse string to convert
  */
 export function convertTraverseStringToClassifier(traverseString: string) {
-  const rawgrade = traverseString.charCodeAt(0) - 'A'.charCodeAt(0);
+  const rawgrade = traverseString.charCodeAt(0) - 'A'.charCodeAt(0) + 1;
   return new RouteClassifier(rawgrade, RouteType.Traverse);
 }
 
@@ -219,7 +219,7 @@ export function getAllCompetitionRouteClassifiers() {
 export function convertCompetitionStringToClassifier(
   competitionString: string
 ) {
-  const rawgrade = competitionString.charCodeAt(0) - 'A'.charCodeAt(0);
+  const rawgrade = competitionString.charCodeAt(0) - 'A'.charCodeAt(0) + 1;
   return new RouteClassifier(rawgrade, RouteType.Competition);
 }
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Cross platform/application utilities.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -21,13 +21,19 @@
     "firebase-tools": "^11.15.0"
   },
   "devDependencies": {
+    "@types/jest": "^29.2.6",
     "@typescript-eslint/eslint-plugin": "^5.43.0",
     "@typescript-eslint/parser": "^5.43.0",
     "eslint": "^8.28.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-prettier": "^4.2.1",
+    "jest": "^29.3.1",
     "prettier": "2.7.1",
+    "ts-jest": "^29.0.5",
     "typescript": ">=3.3.1 <4.9.0"
   },
-  "eslintIgnore": ["api.ts", "types/types.ts"]
+  "eslintIgnore": [
+    "api.ts",
+    "types/types.ts"
+  ]
 }


### PR DESCRIPTION
# Describe your changes
Adds support for constructing `RouteClassifier`s from their representative string. Also configures `jest` as a testing library and adds support for it

# Issue ticket number and link
closes #109, closes #110