### PR TITLE
Add route name to cache on archival

### DIFF
--- a/api/route.ts
+++ b/api/route.ts
@@ -100,13 +100,6 @@ export async function createRoute({
   }
 
   return runTransaction(db, async (transaction: Transaction) => {
-    const cacheDocRef = doc(db, 'caches', 'allRoutes');
-
-    const routeNameToRoute = (await transaction.get(cacheDocRef)).data()!
-      .routeNameToRoute;
-    routeNameToRoute[name] = newRouteDocRef;
-
-    transaction.update(cacheDocRef, { routeNameToRoute: routeNameToRoute });
     transaction.set(newRouteDocRef, {
       name: name,
       rawgrade: classifier.rawgrade,

--- a/types/route.ts
+++ b/types/route.ts
@@ -5,6 +5,7 @@ import {
   arrayRemove,
   arrayUnion,
   deleteDoc,
+  doc,
   refEqual,
   runTransaction,
   serverTimestamp,
@@ -159,6 +160,7 @@ export class Route extends LazyObject {
    */
   public async upgradeStatus() {
     const client_oldStatus = await this.getStatus();
+    const cacheDocRef = doc(db, 'caches', 'archivedRoutes');
 
     return runTransaction(db, async (transaction) => {
       await this.updateWithTransaction(transaction);
@@ -172,6 +174,7 @@ export class Route extends LazyObject {
         });
         this.status = RouteStatus.Active;
       } else {
+        transaction.update(cacheDocRef, { names: arrayUnion(this.name) });
         transaction.update(this.docRef!, { status: RouteStatus.Archived });
         this.status = RouteStatus.Archived;
       }


### PR DESCRIPTION
# Describe your changes
The only place you need to do this is in `upgradeStatus` when upgrading from Active to Archived. Currently, we don't delete non-draft routes, so no problem
# Issue ticket number and link
#82 