### PR TITLE
Comments: add like/unlike & list of users who liked

### DIFF
--- a/types/post.ts
+++ b/types/post.ts
@@ -79,6 +79,7 @@ export class Post extends LazyObject {
         author: author.docRef!,
         textContent: textContent,
         timestamp: serverTimestamp(),
+        likes: [],
         post: this.docRef!,
       });
       transaction.update(author.docRef!, {


### PR DESCRIPTION
# Describe your changes
Added like/unlike to comments, it's a list of users who have liked the comment.
Tested on backend web testing page.

I had to add a comments collection to firestore bc we previously weren't storing comments anywhere.
@JakeSteinebronn lmk what you think but as of rn it works.
![image](https://user-images.githubusercontent.com/73561858/214989836-5a75652f-95bd-4ba5-8f14-d8b121356336.png)

# Issue ticket number and link
Closes #106 