### PR TITLE
add exists to LazyObject and throw from within updateWithTransaction

### DIFF
--- a/types/common.ts
+++ b/types/common.ts
@@ -43,6 +43,7 @@ export class ArrayCursor<T> {
 export abstract class LazyObject {
   public docRef: DocumentReference<DocumentData> | undefined;
   public hasData: boolean;
+  public exists: boolean = true;
 
   public abstract initWithDocumentData(data: DocumentData): void;
 
@@ -52,13 +53,24 @@ export abstract class LazyObject {
       return Promise.reject('Document reference is undefined');
 
     return getDoc(this.docRef).then((docSnap) => {
-      if (!docSnap.exists()) return Promise.reject('Doc snap does not exist');
-      else this.initWithDocumentData(docSnap.data());
+      if (!docSnap.exists()) {
+        this.exists = false;
+        return Promise.reject('Document does not exist');
+      } else {
+        this.exists = true;
+        this.initWithDocumentData(docSnap.data());
+      }
     });
   }
 
   public async updateWithTransaction(transaction: Transaction) {
-    this.initWithDocumentData((await transaction.get(this.docRef!)).data()!);
+    const snap = await transaction.get(this.docRef!);
+    if (!snap.exists) {
+      this.exists = false;
+      return Promise.reject('Document does not exist');
+    }
+    this.exists = true;
+    this.initWithDocumentData(snap.data()!);
   }
 
   constructor(docRef: DocumentReference<DocumentData> | undefined = undefined) {


### PR DESCRIPTION
# Describe your changes
- For checking if a ref is stale, now all you have to do is check object.exists (which is true if you've never called getData)
- Updating with a transaction will throw if the document doesn't exist anymore, which is good because we won't ever do any transacted updates to a nonexistent document anymore
# Issue ticket number and link