### PR TITLE
ArrayCursor gets data and removes stale refs

### DIFF
--- a/types/common.ts
+++ b/types/common.ts
@@ -16,7 +16,7 @@ export enum UserStatus {
   Developer = 5,
 }
 
-export class ArrayCursor<T> {
+export class ArrayCursor<T extends LazyObject> {
   public data: T[];
   private idx: number;
 
@@ -29,9 +29,13 @@ export class ArrayCursor<T> {
     return this.idx < this.data.length;
   }
 
-  public pollNext() {
-    if (!this.hasNext()) return undefined;
-    return this.data[this.idx++];
+  public async pollNext() {
+    while (this.hasNext()) {
+      const res = this.data[this.idx++];
+      await res.getData();
+      if (res.exists) return res;
+    }
+    return undefined;
   }
 
   public peekNext() {


### PR DESCRIPTION
# Describe your changes
Currently, it's possible for arrays (namely User.following) to contain stale references if a user is following a deleted user. For iterating through these lists, we already use the ArrayCursor; to make this easier for frontend to deal with, make `pollNext()` get the object's data and keep polling until it finds an existing object. 
# Issue ticket number and link