### PR TITLE
Mock PostId

### DIFF
--- a/__mocks__/react-native-get-random-values.ts
+++ b/__mocks__/react-native-get-random-values.ts
@@ -1,0 +1,6 @@
+export default {
+  getRandomBase64: jest.fn().mockImplementation(() => {
+    console.log("getRandomBase64 mock called");
+    return "mockedBase64";
+  })
+};

--- a/package.json
+++ b/package.json
@@ -17,8 +17,11 @@
   },
   "homepage": "https://github.com/ucf-tower-app/xplat#readme",
   "dependencies": {
+    "@types/uuid": "^9.0.0",
     "firebase": "^9.12.1",
-    "firebase-tools": "^11.15.0"
+    "firebase-tools": "^11.15.0",
+    "react-native-get-random-values": "^1.8.0",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@types/jest": "^29.2.6",

--- a/types/badge.ts
+++ b/types/badge.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import 'react-native-get-random-values';
+import { v4 as uuidv4 } from 'uuid';
 import { DocumentData } from 'firebase/firestore';
 import { LazyObject } from './types';
 
@@ -36,5 +38,6 @@ export class BadgeMock extends Badge {
     this.description = description;
 
     this.hasData = true;
+    this._idMock = uuidv4();
   }
 }

--- a/types/comment.ts
+++ b/types/comment.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import 'react-native-get-random-values';
+import { v4 as uuidv4 } from 'uuid';
 import {
   DocumentData,
   DocumentReference,
@@ -140,5 +142,6 @@ export class CommentMock extends Comment {
     this.likes = likes;
 
     this.hasData = true;
+    this._idMock = uuidv4();
   }
 }

--- a/types/common.ts
+++ b/types/common.ts
@@ -21,6 +21,18 @@ export abstract class LazyObject {
   public hasData: boolean;
   public exists: boolean = true;
 
+  public _idMock: string | undefined;
+
+  public getId() {
+    if (this.docRef !== undefined) {
+      return this.docRef.id
+    } else if (this._idMock !== undefined) {
+      return this._idMock
+    }
+
+    throw "Cannot fetch ID from LazyObject with no docRef or idMock"; 
+  }
+
   public abstract initWithDocumentData(data: DocumentData): void;
 
   public async getData(forceUpdate = false): Promise<void> {

--- a/types/forum.ts
+++ b/types/forum.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import 'react-native-get-random-values';
+import { v4 as uuidv4 } from 'uuid';
 import { DocumentData, collection, orderBy, where } from 'firebase/firestore';
 import { db } from '../Firebase';
 import { LazyObject, Post, QueryCursor, Route } from './types';
@@ -48,5 +50,6 @@ export class ForumMock extends Forum {
     super();
 
     this.hasData = true;
+    this._idMock = uuidv4();
   }
 }

--- a/types/post.ts
+++ b/types/post.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import 'react-native-get-random-values';
+import { v4 as uuidv4 } from 'uuid';
 import {
   DocumentData,
   DocumentReference,
@@ -271,6 +273,7 @@ export class PostMock extends Post {
     this.videoContent = videoContent;
 
     this.hasData = true;
+    this._idMock = uuidv4();
   }
 
   public addLikes(likes: User[]) {

--- a/types/route.ts
+++ b/types/route.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import 'react-native-get-random-values';
+import { v4 as uuidv4 } from 'uuid';
 import {
   DocumentData,
   DocumentReference,
@@ -563,6 +565,7 @@ export class RouteMock extends Route {
     this.rope = rope;
 
     this.hasData = true;
+    this._idMock = uuidv4();
   }
 
   public addLikes(likes: User[]) {

--- a/types/send.ts
+++ b/types/send.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import 'react-native-get-random-values';
+import { v4 as uuidv4 } from 'uuid';
 import { DocumentData } from 'firebase/firestore';
 import { LazyObject, Route, RouteClassifier, User } from './types';
 
@@ -57,5 +59,6 @@ export class SendMock extends Send {
     this.route = route;
 
     this.hasData = true;
+    this._idMock = uuidv4();
   }
 }

--- a/types/tag.ts
+++ b/types/tag.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import 'react-native-get-random-values';
+import { v4 as uuidv4 } from 'uuid';
 import { DocumentData } from 'firebase/firestore';
 import { LazyObject } from './types';
 
@@ -37,5 +39,6 @@ export class TagMock extends Tag {
     this.description = description;
 
     this.hasData = true;
+    this._idMock = uuidv4();
   }
 }

--- a/types/user.ts
+++ b/types/user.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import 'react-native-get-random-values';
+import { v4 as uuidv4 } from 'uuid';
 import {
   EmailAuthProvider,
   deleteUser,
@@ -531,6 +533,7 @@ export class UserMock extends User {
     this.avatar = avatar;
 
     this.hasData = true;
+    this._idMock = uuidv4();
   }
 
   public addSends(sends: Send[]) {


### PR DESCRIPTION
# Describe your changes
We use mocks in a few places in the production application. An example of which is showing a post preview to a user who is creating a new post. In order for these to work properly with the cache structure, we need their ID.

Previously mocks didn't have IDs, but this PR adds support for an ID with a type safe `getId()` function on Lazy Objects. I looked into simply creating a mock DocRef, but their api is locked down pretty hard with private constructors.

If you want to change how this is done, I simply ask that you keep the function `getId()`, which returns the id of the Lazy Object and throws if it can't find one. Thanks!

# Issue ticket number and link
#3 