### PR TITLE
Moderation Actions

### DIFF
--- a/types/user.ts
+++ b/types/user.ts
@@ -111,8 +111,8 @@ export class User extends LazyObject {
 
     if (!content.hasData) await content.getData();
 
-    // if already reported, return
-    if (await this.alreadyReported(content)) return;
+    // if already reported or already has a significant number of reports (arbitrary), return
+    if (await this.alreadyReported(content) || content.reports?.length! > 7) return;
 
     // update client side
     content.reports?.push(this);
@@ -267,7 +267,7 @@ export class User extends LazyObject {
     await this.checkIfSignedIn();
     if (this.status! < UserStatus.Employee) return Promise.reject('Not an employee, cant moderate!');
 
-    if (!content.hasData) await content.getData();
+    content.getData();
 
     // update client side by deleting all reports from the content's report array
     content.reports = content.reports?.filter(
@@ -343,10 +343,9 @@ export class User extends LazyObject {
       EmailAuthProvider.credential(this.email!, password)
     );
 
-    if (!user.hasData) await user.getData();
+    user.getData();
 
     // delete all content by specified user WITHOUT deleteing their account
-    // todo refactor to reduce code duplication with delete(). Check w Jacob on if this deletes posts & comments
     const preTasks: Promise<any>[] = [];
 
     if (user.avatar && !user.avatar.pathEqual(DEFAULT_AVATAR_PATH))


### PR DESCRIPTION
# Describe your changes
- users are not allowed to report an employee/manager's content
- mark the content as okay (remove all reports on it)
- delete the content (and its reports) without banning the user
- ban the user: don't delete the user, give them permission level -1 banned. These guys must be kept in the DB so they can’t rejoin the app with their knights email, but we can delete their content.
- Employees can give a reason for deleting the content / user (adds to mod log collection)

todo:
- check that our user.delete() function does delete posts & comments, I can't tell where in the code it does that

# Issue ticket number and link
closes sub-tasks for le epic #105
closes #197