### PR TITLE
Hide bio/displayName/avatar on 3+ reports

### DIFF
--- a/Firebase.ts
+++ b/Firebase.ts
@@ -13,3 +13,5 @@ export const auth = getAuth();
 export const storage = getStorage();
 
 export const DEFAULT_AVATAR_PATH = 'avatars/climber.png';
+export const DEFAULT_BIO = "I'm a new climber!";
+export const DEFAULT_DISPLAY_NAME = 'Tower Climber';

--- a/types/user.ts
+++ b/types/user.ts
@@ -128,6 +128,13 @@ export class User extends LazyObject {
     // update client side
     content.reports?.push(this);
 
+    // hide user content if they have 3+ reports. This won't keep them from changing it back, but should be a decent short-term solution.
+    if (content instanceof User && content.reports?.length! >= 3) {
+      content.deleteAvatar();
+      content.setBio("Profile content is under review.");
+      content.setDisplayName("Under Review");
+    }
+
     // update server side
     const newReportDocRef = doc(collection(db, 'reports'));
 

--- a/types/user.ts
+++ b/types/user.ts
@@ -128,17 +128,6 @@ export class User extends LazyObject {
     // update client side
     content.reports?.push(this);
 
-    // hide user content if they have 3+ reports. This won't keep them from changing it back, but should be a decent short-term solution.
-    if (content instanceof User && content.reports?.length! >= 3) {
-      // todo make snapshot of user's content pre-shadowswap.
-      content.setAvatarToDefault();
-      content.setBio("Profile content is under review.");
-      content.setDisplayName("Under Review");
-
-      // todo return runTransaction on a snapshot of the user's content pre-shadowswap. This will show employees their reported content.
-      // todo the issue here is that the snapshot is gonna be hard to delete after. On clearAllReports or deleteReportedContent or banUser we'll need to check if snapshot, and if so, delete that too.
-    }
-
     // update server side
     const newReportDocRef = doc(collection(db, 'reports'));
 
@@ -738,6 +727,25 @@ export class User extends LazyObject {
     } else {
       return this.avatar!.getImageUrl();
     }
+  }
+
+  /** checkShouldBeHidden
+   * Checks if this user's avatar, bio, and display name should be hidden.
+   * @returns true if this content should be hidden, false if not
+   */
+  public async checkShouldBeHidden() {
+    if (!this.hasData) await this.getData();
+    return this.reports!.length >= 3;
+  }
+
+  /** hideProfileContent
+   * Client-side setting of profile content to be default avatar & under review.
+   */
+  public async hideProfileContent() {
+    if (!this.hasData) await this.getData();
+    this.avatar = new LazyStaticImage(DEFAULT_AVATAR_PATH);
+    this.bio = "Profile content is under review.";
+    this.displayName = "Profile under review";
   }
 
   // ======================== Fetchers and Builders ========================

--- a/types/user.ts
+++ b/types/user.ts
@@ -751,24 +751,44 @@ export class User extends LazyObject {
   // ======================== Fetchers and Builders ========================
 
   public async fetch() {
-    return {
-      docRefId: this.docRef!.id,
-      username: await this.getUsername(),
-      email: await this.getEmail(),
-      displayName: await this.getDisplayName(),
-      bio: await this.getBio(),
-      status: await this.getStatus(),
-      avatarUrl: await this.getAvatarUrl(),
-      followingList: this.following ?? [],
-      totalPostSizeInBytes: await this.getTotalPostSizeInBytes(),
-      bestBoulder: await this.getBestSendClassifier(RouteType.Boulder),
-      bestToprope: await this.getBestSendClassifier(RouteType.Toprope),
-      totalSends: await this.getTotalSends(),
-      postsCursor: this.getPostsCursor(),
-      followersCursor: this.getFollowersCursor(),
-      followingCursor: await this.getFollowingCursor(),
-      userObject: this,
-    } as FetchedUser;
+    if (await this.checkShouldBeHidden())
+      return {
+        docRefId: this.docRef!.id,
+        username: await this.getUsername(),
+        email: await this.getEmail(),
+        status: await this.getStatus(),
+        displayName: "Profile under review",
+        bio: "Profile content is under review.",
+        avatarUrl: await getDownloadURL(ref(storage, DEFAULT_AVATAR_PATH)),
+        followingList: this.following ?? [],
+        totalPostSizeInBytes: await this.getTotalPostSizeInBytes(),
+        bestBoulder: await this.getBestSendClassifier(RouteType.Boulder),
+        bestToprope: await this.getBestSendClassifier(RouteType.Toprope),
+        totalSends: await this.getTotalSends(),
+        postsCursor: this.getPostsCursor(),
+        followersCursor: this.getFollowersCursor(),
+        followingCursor: await this.getFollowingCursor(),
+        userObject: this,
+      } as FetchedUser;
+    else
+      return {
+        docRefId: this.docRef!.id,
+        username: await this.getUsername(),
+        email: await this.getEmail(),
+        status: await this.getStatus(),
+        displayName: await this.getDisplayName(),
+        bio: await this.getBio(),
+        avatarUrl: await this.getAvatarUrl(),
+        followingList: this.following ?? [],
+        totalPostSizeInBytes: await this.getTotalPostSizeInBytes(),
+        bestBoulder: await this.getBestSendClassifier(RouteType.Boulder),
+        bestToprope: await this.getBestSendClassifier(RouteType.Toprope),
+        totalSends: await this.getTotalSends(),
+        postsCursor: this.getPostsCursor(),
+        followersCursor: this.getFollowersCursor(),
+        followingCursor: await this.getFollowingCursor(),
+        userObject: this,
+      } as FetchedUser;
   }
 
   public buildFetcher() {

--- a/types/user.ts
+++ b/types/user.ts
@@ -735,7 +735,7 @@ export class User extends LazyObject {
    */
   public async checkShouldBeHidden() {
     if (!this.hasData) await this.getData();
-    return this.reports!.length >= 3;
+    return this.reports!.length >= 5;
   }
 
   /** hideProfileContent


### PR DESCRIPTION
# Describe your changes
Instead of changing user bio/avatar/displayName on server-side (too many changes to our reporting system, making a snapshot of user's bad content then keeping a reference to it and managing that on moderation actions), we'll hide user profile content just like we do with Posts & Comments. Front end should checkShouldBeHidden(), and if true they can use hideProfileContent().

There may still be some artifacts of NSFW on displayName and stuff like that, I'm not sure. But those will get wiped out on moderation actions once employees get to it & this is a great start.

# Issue ticket number and link
closes #196