### PR TITLE
delete reports on content deletion

### DIFF
--- a/types/comment.ts
+++ b/types/comment.ts
@@ -11,12 +11,19 @@ import {
   refEqual,
   runTransaction,
   updateDoc,
-  where
+  where,
 } from 'firebase/firestore';
 import 'react-native-get-random-values';
 import { v4 as uuidv4 } from 'uuid';
 import { db } from '../Firebase';
-import { LazyObject, Post, QueryCursor, Report, User, containsRef } from '../types';
+import {
+  LazyObject,
+  Post,
+  QueryCursor,
+  Report,
+  User,
+  containsRef,
+} from '../types';
 
 export type FetchedComment = {
   author: User;
@@ -68,8 +75,8 @@ export class Comment extends LazyObject {
   }
 
   /** getReportsCursor
-  * get a QueryCursor for a Comment's reports starting from most recent
-  */
+   * get a QueryCursor for a Comment's reports starting from most recent
+   */
   public getReportsCursor() {
     return new QueryCursor(
       Report,
@@ -90,20 +97,18 @@ export class Comment extends LazyObject {
     const tasks = [];
 
     (
-    await this.getReportsCursor().________getAll_CLOWNTOWN_LOTS_OF_READS()
+      await this.getReportsCursor().________getAll_CLOWNTOWN_LOTS_OF_READS()
     ).forEach((rpt) => tasks.push(deleteDoc(rpt?.docRef!)));
 
     tasks.push(deleteDoc(this.docRef!));
-
-    console.log('deleting ' + tasks.length + ' comments');
 
     return Promise.all(tasks);
   }
 
   /** checkShouldBeHidden
-  * Checks if this content should be hidden (if over 3 of reports)
-  * @returns true if this content should be hidden, false if not
-  */
+   * Checks if this content should be hidden (if over 3 of reports)
+   * @returns true if this content should be hidden, false if not
+   */
   public async checkShouldBeHidden() {
     if (!this.hasData) await this.getData();
     return this.reports!.length >= 3;

--- a/types/comment.ts
+++ b/types/comment.ts
@@ -83,9 +83,10 @@ export class Comment extends LazyObject {
   /** delete
    * Delete this comment
    */
-  public async delete() { // todo test
+  public async delete() {
     // no longer refreshingly simple :(
     if (!this.docRef) return;
+    await this.getData(true);
     const tasks = [];
 
     (
@@ -93,6 +94,8 @@ export class Comment extends LazyObject {
     ).forEach((rpt) => tasks.push(deleteDoc(rpt?.docRef!)));
 
     tasks.push(deleteDoc(this.docRef!));
+
+    console.log('deleting ' + tasks.length + ' comments');
 
     return Promise.all(tasks);
   }

--- a/types/post.ts
+++ b/types/post.ts
@@ -22,6 +22,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { db } from '../Firebase';
 import {
   Comment,
+  Report,
   Forum,
   LazyObject,
   LazyStaticImage,
@@ -143,6 +144,19 @@ export class Post extends LazyObject {
       5,
       collection(db, 'comments'),
       where('post', '==', this.docRef!),
+      orderBy('timestamp', 'desc')
+    );
+  }
+
+  /** getReportsCursor
+   * get a QueryCursor for a Post's reports starting from most recent
+   */
+  public getReportsCursor() {
+    return new QueryCursor(
+      Report,
+      5,
+      collection(db, 'reports'),
+      where('content', '==', this.docRef!),
       orderBy('timestamp', 'desc')
     );
   }
@@ -311,17 +325,21 @@ export class Post extends LazyObject {
     await deleteVideo;
   }
 
-  public async delete() {
+  public async delete() { // todo test
     if (!this.docRef) return;
     await this.getData(true);
     const size = await this.getStaticContentSizeInBytes();
     const tasks = [];
     tasks.push(this.deleteStaticContent());
 
+    // Delete comments and reports on this post
     // It's fine because they'd have to be read to be deleted anyway :)
     (
       await this.getCommentsCursor().________getAll_CLOWNTOWN_LOTS_OF_READS()
     ).forEach((cmt) => tasks.push(deleteDoc(cmt?.docRef!)));
+    (
+      await this.getReportsCursor().________getAll_CLOWNTOWN_LOTS_OF_READS()
+    ).forEach((rpt) => tasks.push(deleteDoc(rpt?.docRef!)));
 
     tasks.push(
       runTransaction(db, async (transaction: Transaction) => {

--- a/types/post.ts
+++ b/types/post.ts
@@ -22,12 +22,12 @@ import { v4 as uuidv4 } from 'uuid';
 import { db } from '../Firebase';
 import {
   Comment,
-  Report,
   Forum,
   LazyObject,
   LazyStaticImage,
   LazyStaticVideo,
   QueryCursor,
+  Report,
   User,
   containsRef,
 } from '../types';
@@ -325,7 +325,7 @@ export class Post extends LazyObject {
     await deleteVideo;
   }
 
-  public async delete() { // todo test
+  public async delete() {
     if (!this.docRef) return;
     await this.getData(true);
     const size = await this.getStaticContentSizeInBytes();
@@ -334,9 +334,10 @@ export class Post extends LazyObject {
 
     // Delete comments and reports on this post
     // It's fine because they'd have to be read to be deleted anyway :)
+    console.log('about to delete comments from posts');
     (
       await this.getCommentsCursor().________getAll_CLOWNTOWN_LOTS_OF_READS()
-    ).forEach((cmt) => tasks.push(deleteDoc(cmt?.docRef!)));
+    ).forEach((cmt) => tasks.push(cmt?.delete()));
     (
       await this.getReportsCursor().________getAll_CLOWNTOWN_LOTS_OF_READS()
     ).forEach((rpt) => tasks.push(deleteDoc(rpt?.docRef!)));
@@ -354,6 +355,9 @@ export class Post extends LazyObject {
           .delete(this.docRef!);
       })
     );
+
+    console.log('deleting ' + tasks.length + ' posts & comments');
+
     return Promise.all(tasks);
   }
 }

--- a/types/post.ts
+++ b/types/post.ts
@@ -334,7 +334,6 @@ export class Post extends LazyObject {
 
     // Delete comments and reports on this post
     // It's fine because they'd have to be read to be deleted anyway :)
-    console.log('about to delete comments from posts');
     (
       await this.getCommentsCursor().________getAll_CLOWNTOWN_LOTS_OF_READS()
     ).forEach((cmt) => tasks.push(cmt?.delete()));
@@ -355,8 +354,6 @@ export class Post extends LazyObject {
           .delete(this.docRef!);
       })
     );
-
-    console.log('deleting ' + tasks.length + ' posts & comments');
 
     return Promise.all(tasks);
   }

--- a/types/user.ts
+++ b/types/user.ts
@@ -269,20 +269,26 @@ export class User extends LazyObject {
     if (!this.docRef) return;
     const tasks: any[] = [];
 
-    // delete all reports // todo test
+    // delete all their reports
+    console.log('about to delete reports from user');
+
     (
     await this.getReportsCursor().________getAll_CLOWNTOWN_LOTS_OF_READS()
     ).forEach((rpt) => tasks.push(deleteDoc(rpt?.docRef!)));
 
-    // delete all posts // todo test
+    console.log('about to delete all posts from user');
+    // delete all their posts, which also deletes posts' reports & comments & comments' reports
     (
     await this.getPostsCursor().________getAll_CLOWNTOWN_LOTS_OF_READS()
-    ).forEach((post) => tasks.push(deleteDoc(post?.docRef!)));
+    ).forEach((post) => tasks.push(post?.delete()));
 
-    // delete all comments // todo test
+    console.log('about to delete all comments from user');
+    // delete all ther comments, which also deletes comments' reports
     (
     await this.getCommentsCursor().________getAll_CLOWNTOWN_LOTS_OF_READS()
-    ).forEach((cmt) => tasks.push(deleteDoc(cmt?.docRef!)));
+    ).forEach((cmt) => tasks.push(cmt?.delete()));
+
+    console.log('clearing effects ' + tasks.length + ' tasks');
 
     await Promise.all(tasks);
   }

--- a/types/user.ts
+++ b/types/user.ts
@@ -56,7 +56,7 @@ import {
   Send,
   UserStatus,
   containsRef,
-  removeRef
+  removeRef,
 } from '../types';
 
 export interface FetchedUser {
@@ -249,8 +249,8 @@ export class User extends LazyObject {
   }
 
   /** getReportsCursor
-  * get a QueryCursor for a Comment's reports starting from most recent
-  */
+   * get a QueryCursor for a Comment's reports starting from most recent
+   */
   public getReportsCursor() {
     return new QueryCursor(
       Report,
@@ -270,25 +270,17 @@ export class User extends LazyObject {
     const tasks: any[] = [];
 
     // delete all their reports
-    console.log('about to delete reports from user');
-
     (
-    await this.getReportsCursor().________getAll_CLOWNTOWN_LOTS_OF_READS()
+      await this.getReportsCursor().________getAll_CLOWNTOWN_LOTS_OF_READS()
     ).forEach((rpt) => tasks.push(deleteDoc(rpt?.docRef!)));
-
-    console.log('about to delete all posts from user');
     // delete all their posts, which also deletes posts' reports & comments & comments' reports
     (
-    await this.getPostsCursor().________getAll_CLOWNTOWN_LOTS_OF_READS()
+      await this.getPostsCursor().________getAll_CLOWNTOWN_LOTS_OF_READS()
     ).forEach((post) => tasks.push(post?.delete()));
-
-    console.log('about to delete all comments from user');
     // delete all ther comments, which also deletes comments' reports
     (
-    await this.getCommentsCursor().________getAll_CLOWNTOWN_LOTS_OF_READS()
+      await this.getCommentsCursor().________getAll_CLOWNTOWN_LOTS_OF_READS()
     ).forEach((cmt) => tasks.push(cmt?.delete()));
-
-    console.log('clearing effects ' + tasks.length + ' tasks');
 
     await Promise.all(tasks);
   }
@@ -321,7 +313,6 @@ export class User extends LazyObject {
     await this.clearEffects();
 
     await Promise.all(preTasks);
-    console.log('Pre-tasks done');
 
     // remove user from cache
     await runTransaction(db, async (transaction) => {
@@ -345,12 +336,9 @@ export class User extends LazyObject {
         })
       );
     });
-    console.log('Main transaction done');
 
     await deleteDoc(this.docRef!);
-    console.log('Document deleted');
     await deleteUser(auth.currentUser!);
-    console.log('Auth deleted');
   }
 
   /** clearAllReports
@@ -471,7 +459,6 @@ export class User extends LazyObject {
       },
       { merge: true }
     );
-
   }
 
   /** banUser
@@ -503,7 +490,6 @@ export class User extends LazyObject {
     await this.clearEffects();
 
     await Promise.all(preTasks);
-    console.log('Pre-tasks done');
 
     // remove user from cache
     await runTransaction(db, async (transaction) => {
@@ -522,7 +508,6 @@ export class User extends LazyObject {
         }),
       });
     });
-    console.log('Main transaction done');
 
     // update user status to banned
     await runTransaction(db, async (transaction: Transaction) => {


### PR DESCRIPTION
# Describe your changes
- delete all existing reports on content that gets deleted
- delete all existing reports when banning / deleting a user
- delete all comments & posts when deleting a user (do it recursively in the sense that deleting a comment also deletes all reports on that comment)

@JakeSteinebronn I had to add some more [Firestore indexes](https://console.firebase.google.com/u/0/project/ucf-tower/firestore/indexes?create_composite=Cklwcm9qZWN0cy91Y2YtdG93ZXIvZGF0YWJhc2VzLyhkZWZhdWx0KS9jb2xsZWN0aW9uR3JvdXBzL3JlcG9ydHMvaW5kZXhlcy9fEAEaDAoIcmVwb3J0ZXIQARoNCgl0aW1lc3RhbXAQAhoMCghfX25hbWVfXxAC), console errors prompted me to do so even if it was redundant. And now it works 🤷‍♂️ 

![image](https://user-images.githubusercontent.com/73561858/220495741-43792a3a-84ad-46fd-ab4a-56f584fd5abd.png)


# Issue ticket number and link
closes #230, #193