### PR TITLE
Report/constructpage

### DIFF
--- a/queries.ts
+++ b/queries.ts
@@ -10,6 +10,7 @@ export * from './queries/forum';
 export * from './queries/leaderboard';
 export * from './queries/post';
 export * from './queries/user';
+export * from './queries/report';
 
 export function constructPageData<T extends LazyObject>(
   Tcreator: new (data: DocumentReference) => T,

--- a/queries/report.ts
+++ b/queries/report.ts
@@ -43,23 +43,21 @@ export type ReportedContent = {
 export function constructReportPageData(docs: QueryDocumentSnapshot<DocumentData>[]): ReportedContent[] {
   return docs.map((doc) => {
     const data = doc.data();
-    
-    const reporterPathArr = data.reporter._key.path.segments;
     const reporter = new User(data.reporter);
     const contentPathArr = data.content._key.path.segments;
     if (contentPathArr.includes('posts'))
     {
-      const p = new Post(data.content);
-      return {content: p, reporter: reporter} as ReportedContent; 
+      const post = new Post(data.content);
+      return {content: post, reporter: reporter} as ReportedContent; 
     }
     if (contentPathArr.includes('comments'))
     {
-      const c = new Comment(data.content);
-      return {content: c, reporter: reporter} as ReportedContent;
+      const comment = new Comment(data.content);
+      return {content: comment, reporter: reporter} as ReportedContent;
     }
     
-    const u = new User(data.content);
-    return {content: u, reporter: reporter} as ReportedContent;
+    const user = new User(data.content);
+    return {content: user, reporter: reporter} as ReportedContent;
     
   });
 }

--- a/queries/report.ts
+++ b/queries/report.ts
@@ -5,7 +5,10 @@ import {
   orderBy,
   query,
   startAfter,
+  QueryDocumentSnapshot,
+  DocumentData,
 } from 'firebase/firestore';
+import { Post, Comment, User } from '../types';
 import { db } from '../Firebase';
 
 const STRIDE = 3;
@@ -30,4 +33,31 @@ export function getIQParams_Reports() {
       else return lastPage[lastPage.length - 1];
     },
   };
+}
+
+export type ReportedContent = {
+  content: User | Comment | Post;
+  reporters: User[];
+}
+
+export function constructReportPageData(docs: QueryDocumentSnapshot<DocumentData>[]) {
+  return docs.map((doc) => {
+    const data = doc.data();
+    console.log(data);
+    const pathArr = data.content._key.path.segments;
+    if (pathArr.includes('posts'))
+    {
+      const p = new Post(pathArr[pathArr.length - 1]);
+      return p; 
+    }
+    if (pathArr.includes('comments'))
+    {
+      const c = new Comment(pathArr[pathArr.length - 1]);
+      return c;
+    }
+    
+    const u = new User(pathArr[pathArr.length - 1]);
+    return u;
+    
+  });
 }

--- a/queries/report.ts
+++ b/queries/report.ts
@@ -37,27 +37,29 @@ export function getIQParams_Reports() {
 
 export type ReportedContent = {
   content: User | Comment | Post;
-  reporters: User[];
+  reporter: User;
 }
 
-export function constructReportPageData(docs: QueryDocumentSnapshot<DocumentData>[]) {
+export function constructReportPageData(docs: QueryDocumentSnapshot<DocumentData>[]): ReportedContent[] {
   return docs.map((doc) => {
     const data = doc.data();
-    console.log(data);
-    const pathArr = data.content._key.path.segments;
-    if (pathArr.includes('posts'))
+    
+    const reporterPathArr = data.reporter._key.path.segments;
+    const reporter = new User(data.reporter);
+    const contentPathArr = data.content._key.path.segments;
+    if (contentPathArr.includes('posts'))
     {
-      const p = new Post(pathArr[pathArr.length - 1]);
-      return p; 
+      const p = new Post(data.content);
+      return {content: p, reporter: reporter} as ReportedContent; 
     }
-    if (pathArr.includes('comments'))
+    if (contentPathArr.includes('comments'))
     {
-      const c = new Comment(pathArr[pathArr.length - 1]);
-      return c;
+      const c = new Comment(data.content);
+      return {content: c, reporter: reporter} as ReportedContent;
     }
     
-    const u = new User(pathArr[pathArr.length - 1]);
-    return u;
+    const u = new User(data.content);
+    return {content: u, reporter: reporter} as ReportedContent;
     
   });
 }


### PR DESCRIPTION
# Describe your changes

- Add `constructReportPageData` to `queries/report.ts`. This constructs an array of objects of type `{content: Post | Comment | User, reporter: User}` for the frontend to parse.
- Adds report export statement to `queries.ts`

I've tested this on frontend and it works as intended.

# Issue ticket number and link